### PR TITLE
Fix RCTBridgeModule import to work with newer react-native version

### DIFF
--- a/ios/RCTFileUploader/RCTFileUploader.h
+++ b/ios/RCTFileUploader/RCTFileUploader.h
@@ -9,7 +9,11 @@
 //
 
 #import <Foundation/Foundation.h>
-#import "RCTBridgeModule.h"
+#if __has_include(<React/RCTBridgeModule.h>)
+  #import <React/RCTBridgeModule.h>
+#else
+  #import "RCTBridgeModule.h"
+#endif 
 
 @interface RCTFileUploader : NSObject<RCTBridgeModule>
 


### PR DESCRIPTION
The current library breaks on newer RN version.

This patch fixes it by checking what kind of library it has to import, keeping backward-compatibility.